### PR TITLE
refactor: Simplify UI language for monthly plans

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
     <a href="#" id="nav-month-1">
         <i class="bi bi-1-circle nav-icon"></i>
         <i class="bi bi-check-circle-fill nav-icon-completed"></i>
-        <span class="nav-text">Month 1 Sprint</span>
+        <span class="nav-text">30 Day Plan</span>
         <div class="nav-progress-donut-container">
             <svg class="progress-donut" viewBox="0 0 24 24">
                 <circle class="progress-donut__track" cx="12" cy="12" r="10" fill="transparent" stroke-width="3"></circle>
@@ -154,7 +154,7 @@
     <a href="#" id="nav-month-2">
         <i class="bi bi-2-circle nav-icon"></i>
         <i class="bi bi-check-circle-fill nav-icon-completed"></i>
-        <span class="nav-text">Month 2 Sprint</span>
+        <span class="nav-text">60 Day Plan</span>
         <div class="nav-progress-donut-container">
             <svg class="progress-donut" viewBox="0 0 24 24">
                 <circle class="progress-donut__track" cx="12" cy="12" r="10" fill="transparent" stroke-width="3"></circle>
@@ -165,7 +165,7 @@
     <a href="#" id="nav-month-3">
         <i class="bi bi-3-circle nav-icon"></i>
         <i class="bi bi-check-circle-fill nav-icon-completed"></i>
-        <span class="nav-text">Month 3 Sprint</span>
+        <span class="nav-text">90 Day Plan</span>
         <div class="nav-progress-donut-container">
             <svg class="progress-donut" viewBox="0 0 24 24">
                 <circle class="progress-donut__track" cx="12" cy="12" r="10" fill="transparent" stroke-width="3"></circle>

--- a/script.js
+++ b/script.js
@@ -817,9 +817,9 @@ function runApp(app) {
         }
         const titles = {
             vision: { title: 'Bakery Growth Plan', subtitle: appState.planData.planName || 'Your 90-Day Sprint to a Better Bakery.'},
-            'month-1': { title: 'Month 1 Sprint', subtitle: 'Lay the foundations for success.'},
-            'month-2': { title: 'Month 2 Sprint', subtitle: 'Build momentum and embed processes.'},
-            'month-3': { title: 'Month 3 Sprint', subtitle: 'Refine execution and review the quarter.'},
+            'month-1': { title: '30 Day Plan', subtitle: 'Lay the foundations for success.'},
+            'month-2': { title: '60 Day Plan', subtitle: 'Build momentum and embed processes.'},
+            'month-3': { title: '90 Day Plan', subtitle: 'Refine execution and review the quarter.'},
             summary: { title: '90-Day Plan Summary', subtitle: 'A complete overview of your quarterly plan.'}
         };
         DOMElements.headerTitle.textContent = titles[viewId]?.title || 'Growth Plan';
@@ -907,7 +907,7 @@ function runApp(app) {
             }
 
             return `<div class="content-card p-0 overflow-hidden mt-8">
-                        <h2 class="text-2xl font-bold font-poppins p-6 bg-gray-50 border-b">Month ${monthNum} Sprint</h2>
+                        <h2 class="text-2xl font-bold font-poppins p-6 bg-gray-50 border-b">${monthNum * 30} Day Plan</h2>
                         <div class="summary-grid">
                             <div class="p-6">
                                 ${pillarHTML}


### PR DESCRIPTION
This commit updates the user interface to use simpler and more direct language for the monthly planning sections. The following changes have been made:

- "Month 1 Sprint" is now "30 Day Plan"
- "Month 2 Sprint" is now "60 Day Plan"
- "Month 3 Sprint" is now "90 Day Plan"

These changes are applied consistently across the application, including the sidebar navigation, page titles, and summary views.