### PR TITLE
feat: Allow user to upload a profile photo

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -28,6 +28,28 @@
 
         <main id="content-area" class="p-4 sm:p-6 lg:p-8">
             <div class="content-card p-8">
+                <div id="profile-photo-section" class="flex items-center space-x-6 mb-8 pb-8 border-b">
+                    <div class="relative">
+                        <img id="profile-photo-preview" class="w-24 h-24 rounded-full object-cover bg-gray-200" src="https://ssl.gstatic.com/images/branding/product/1x/avatar_circle_blue_512dp.png" alt="Profile preview">
+                        <button id="remove-photo-btn" class="absolute bottom-0 right-0 btn-remove-photo no-print hidden" title="Remove photo">
+                            <i class="bi bi-trash-fill"></i>
+                        </button>
+                    </div>
+                    <div>
+                        <h3 class="font-semibold text-lg">Profile Photo</h3>
+                        <p class="text-sm text-gray-500 mt-1 mb-3">Upload a new photo. This is optional.</p>
+                        <label for="photo-upload-input" class="btn btn-secondary cursor-pointer">
+                            <i class="bi bi-upload"></i>
+                            <span>Upload</span>
+                        </label>
+                        <input type="file" id="photo-upload-input" class="hidden" accept="image/png, image/jpeg">
+                        <button id="save-photo-btn" class="btn btn-primary hidden ml-2">
+                            <i class="bi bi-save-fill"></i>
+                            <span>Save</span>
+                        </button>
+                    </div>
+                </div>
+
                 <div class="space-y-6">
                     <div>
                         <label for="profile-name" class="font-semibold block mb-2">Name:</label>
@@ -52,6 +74,7 @@
     <script src="https://www.gstatic.com/firebasejs/9.6.7/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.6.7/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.6.7/firebase-firestore-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.6.7/firebase-storage-compat.js"></script>
 
     <script src="profile.js"></script>
 

--- a/profile.js
+++ b/profile.js
@@ -21,36 +21,151 @@ async function initializeFirebase() {
 function runProfileScript(app) {
     const auth = firebase.auth();
     const db = firebase.firestore();
+    const storage = firebase.storage();
 
     const DOMElements = {
         profileName: document.getElementById('profile-name'),
         profileEmail: document.getElementById('profile-email'),
         backToDashboardBtn: document.getElementById('back-to-dashboard-btn'),
+        photoPreview: document.getElementById('profile-photo-preview'),
+        photoUploadInput: document.getElementById('photo-upload-input'),
+        savePhotoBtn: document.getElementById('save-photo-btn'),
+        removePhotoBtn: document.getElementById('remove-photo-btn'),
     };
 
-    auth.onAuthStateChanged(async (user) => {
-        if (user) {
-            // User is signed in.
-            DOMElements.profileEmail.value = user.email;
+    let currentUser = null;
+    let selectedFile = null;
+    const defaultPhotoURL = 'https://ssl.gstatic.com/images/branding/product/1x/avatar_circle_blue_512dp.png';
 
-            // Fetch user's name from Firestore
-            const userDoc = await db.collection('users').doc(user.uid).get();
-            if (userDoc.exists && userDoc.data().name) {
-                DOMElements.profileName.value = userDoc.data().name;
-            } else {
-                // Look for the name in any of the user's plans
-                const plansRef = db.collection('users').doc(user.uid).collection('plans');
-                const snapshot = await plansRef.orderBy('lastEdited', 'desc').limit(1).get();
-                if (!snapshot.empty) {
-                    const planData = snapshot.docs[0].data();
-                    DOMElements.profileName.value = planData.managerName || 'No name set';
+    // ====================================================================
+    // PHOTO MANAGEMENT FUNCTIONS
+    // ====================================================================
+
+    function loadUserProfile(user) {
+        DOMElements.profileEmail.value = user.email;
+        const userRef = db.collection('users').doc(user.uid);
+
+        userRef.get().then(async (doc) => {
+            if (doc.exists) {
+                const data = doc.data();
+                // Load photo
+                if (data.photoURL) {
+                    DOMElements.photoPreview.src = data.photoURL;
+                    DOMElements.removePhotoBtn.classList.remove('hidden');
                 } else {
-                    DOMElements.profileName.value = 'No name set';
+                    DOMElements.photoPreview.src = defaultPhotoURL;
+                    DOMElements.removePhotoBtn.classList.add('hidden');
+                }
+                // Load name
+                if (data.name) {
+                    DOMElements.profileName.value = data.name;
+                } else {
+                    // Fallback to find name in plans
+                    const plansRef = userRef.collection('plans');
+                    const snapshot = await plansRef.orderBy('lastEdited', 'desc').limit(1).get();
+                    if (!snapshot.empty) {
+                        const planData = snapshot.docs[0].data();
+                        DOMElements.profileName.value = planData.managerName || 'No name set';
+                    } else {
+                        DOMElements.profileName.value = 'No name set';
+                    }
                 }
             }
+        }).catch(error => {
+            console.error("Error fetching user data:", error);
+        });
+    }
+
+    function handleFileSelect(e) {
+        const file = e.target.files[0];
+        if (!file) return;
+
+        // Simple validation
+        if (file.size > 5 * 1024 * 1024) { // 5MB limit
+            alert('File is too large. Please select a file smaller than 5MB.');
+            return;
+        }
+
+        const reader = new FileReader();
+        reader.onload = (event) => {
+            DOMElements.photoPreview.src = event.target.result;
+            DOMElements.savePhotoBtn.classList.remove('hidden');
+            DOMElements.removePhotoBtn.classList.remove('hidden');
+        };
+        reader.readAsDataURL(file);
+        selectedFile = file;
+    }
+
+    async function savePhoto() {
+        if (!selectedFile || !currentUser) return;
+
+        const uploadPath = `profile_photos/${currentUser.uid}/${selectedFile.name}`;
+        const fileRef = storage.ref(uploadPath);
+
+        try {
+            DOMElements.savePhotoBtn.disabled = true;
+            DOMElements.savePhotoBtn.innerHTML = '<i class="bi bi-arrow-repeat"></i><span>Saving...</span>';
+
+            const snapshot = await fileRef.put(selectedFile);
+            const photoURL = await snapshot.ref.getDownloadURL();
+
+            await db.collection('users').doc(currentUser.uid).set({ photoURL: photoURL }, { merge: true });
+
+            DOMElements.savePhotoBtn.classList.add('hidden');
+            DOMElements.photoPreview.src = photoURL;
+            selectedFile = null;
+            alert('Profile photo updated successfully!');
+
+        } catch (error) {
+            console.error("Error uploading photo:", error);
+            alert('There was an error uploading your photo. Please try again.');
+        } finally {
+            DOMElements.savePhotoBtn.disabled = false;
+            DOMElements.savePhotoBtn.innerHTML = '<i class="bi bi-save-fill"></i><span>Save</span>';
+        }
+    }
+
+    async function removePhoto() {
+        if (!currentUser) return;
+        if (!confirm("Are you sure you want to remove your profile photo?")) return;
+
+        const userRef = db.collection('users').doc(currentUser.uid);
+
+        try {
+            // First, remove the photoURL from Firestore
+            await userRef.update({ photoURL: firebase.firestore.FieldValue.delete() });
+
+            // Try to delete from Storage. This might fail if the user has a photo from an old system, so we wrap it.
+            try {
+                const photoRef = storage.refFromURL(DOMElements.photoPreview.src);
+                await photoRef.delete();
+            } catch (storageError) {
+                // If the file doesn't exist in storage (e.g. old URL, permissions issue), log it but don't block the user.
+                console.warn("Could not delete photo from storage:", storageError.message);
+            }
+
+            DOMElements.photoPreview.src = defaultPhotoURL;
+            DOMElements.removePhotoBtn.classList.add('hidden');
+            DOMElements.savePhotoBtn.classList.add('hidden');
+            selectedFile = null;
+            alert('Profile photo removed.');
+
+        } catch (error) {
+            console.error("Error removing photo:", error);
+            alert('There was an error removing your photo.');
+        }
+    }
+
+    // ====================================================================
+    // AUTHENTICATION AND EVENT LISTENERS
+    // ====================================================================
+
+    auth.onAuthStateChanged((user) => {
+        if (user) {
+            currentUser = user;
+            loadUserProfile(user);
         } else {
-            // User is not signed in.
-            // Redirect to login page
+            currentUser = null;
             window.location.href = '/index.html';
         }
     });
@@ -58,6 +173,10 @@ function runProfileScript(app) {
     DOMElements.backToDashboardBtn.addEventListener('click', () => {
         window.location.href = '/index.html';
     });
+
+    DOMElements.photoUploadInput.addEventListener('change', handleFileSelect);
+    DOMElements.savePhotoBtn.addEventListener('click', savePhoto);
+    DOMElements.removePhotoBtn.addEventListener('click', removePhoto);
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/style.css
+++ b/style.css
@@ -949,3 +949,25 @@ tr:hover .btn-remove-row {
     background-color: var(--gails-grey-light);
     cursor: not-allowed;
 }
+
+.btn-remove-photo {
+    background-color: rgba(17, 24, 39, 0.6);
+    backdrop-filter: blur(4px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: var(--gails-white);
+    border-radius: 9999px;
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: all 0.2s ease;
+}
+
+.btn-remove-photo:hover {
+    background-color: var(--gails-red);
+    color: var(--gails-white);
+    transform: scale(1.1);
+}


### PR DESCRIPTION
This commit introduces the ability for users to upload an optional profile photo on their profile page.

Key changes:
- Modified `profile.html` to add the photo upload UI, including a preview image, upload button, and remove button.
- Updated `profile.js` to handle the logic for:
  - Selecting a local image file.
  - Displaying a preview of the selected image.
  - Uploading the image to Firebase Storage under a `profile_photos/{userId}` path.
  - Saving the public photo URL to the user's document in Firestore.
  - Removing the photo from both Firestore and Firebase Storage.
  - Loading the user's existing photo on page load.
- Added `firebase-storage-compat.js` script to `profile.html`.
- Added styles to `style.css` for the new `btn-remove-photo` button to ensure it matches the site's aesthetic.