### PR TITLE
Update calendar styles for better visual appeal

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,11 +261,13 @@
     <div id="calendar-modal" class="calendar-modal hidden">
         <div class="calendar-modal-content">
             <div class="calendar-header">
-                <button id="calendar-prev-month-btn" class="btn btn-secondary"><i class="bi bi-chevron-left"></i></button>
+                <div class="calendar-nav-container">
+                    <button id="calendar-prev-month-btn" class="btn btn-secondary"><i class="bi bi-chevron-left"></i></button>
+                    <button id="calendar-next-month-btn" class="btn btn-secondary"><i class="bi bi-chevron-right"></i></button>
+                    <button id="calendar-today-btn" class="btn btn-secondary">Today</button>
+                </div>
                 <h2 id="calendar-month-year" class="text-2xl font-bold"></h2>
-                <button id="calendar-next-month-btn" class="btn btn-secondary"><i class="bi bi-chevron-right"></i></button>
-                <button id="calendar-today-btn" class="btn btn-secondary">Today</button>
-                <button id="calendar-close-btn" class="btn btn-secondary absolute top-4 right-4"><i class="bi bi-x-lg"></i></button>
+                <button id="calendar-close-btn" class="btn btn-secondary"><i class="bi bi-x-lg"></i></button>
             </div>
             <div id="calendar-grid" class="calendar-grid"></div>
         </div>

--- a/style.css
+++ b/style.css
@@ -1014,6 +1014,7 @@ tr:hover .btn-remove-row {
     flex-direction: column;
     box-shadow: var(--shadow-lg);
     overflow: hidden; /* Prevent inner content from breaking out */
+    padding: 1rem; /* Add padding to the modal content */
 }
 
 .calendar-header {
@@ -1028,6 +1029,12 @@ tr:hover .btn-remove-row {
     gap: 1rem; /* Add gap between elements */
 }
 
+.calendar-nav-container {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
 #calendar-month-year {
     font-family: 'Poppins', sans-serif;
     font-size: 1.5rem;
@@ -1035,6 +1042,9 @@ tr:hover .btn-remove-row {
     margin: 0; /* Remove large margin */
     text-align: center;
     flex-grow: 1; /* Allow title to take space */
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
 }
 
 .calendar-header .btn {
@@ -1054,7 +1064,6 @@ tr:hover .btn-remove-row {
     height: 2.5rem; /* 40px */
     border-radius: 0.75rem; /* Match other buttons */
     font-weight: 600;
-    order: -1; /* Move to the left */
 }
 
 #calendar-close-btn {


### PR DESCRIPTION
This commit addresses the following visual improvements to the calendar modal:

1.  **Button Realignment:** The 'Previous Month', 'Next Month', and 'Today' buttons are now grouped together on the left side of the header for a more intuitive user experience.
2.  **Centered Month Text:** The month and year text is now properly centered in the calendar header.
3.  **Increased Padding:** Padding has been added around the calendar to prevent it from touching the edges of the modal, improving the overall visual layout.