### PR TITLE
Fix: Prevent calendar stretching with more than 3 events per day

### DIFF
--- a/script.js
+++ b/script.js
@@ -1667,19 +1667,37 @@ function runApp(app) {
             dotsContainer.classList.add('event-dots-container');
             
             const dayEvents = appState.calendar.data[dateKey];
-            if (Array.isArray(dayEvents)) {
-                const eventTypes = new Set(dayEvents.map(e => e.type));
-eventTypes.forEach(type => {
-    let element;
-    if (type === 'birthday') {
-        element = document.createElement('i');
-        element.className = 'bi bi-cake2';
-    } else {
-        element = document.createElement('div');
-        element.className = `event-dot option-dot ${type}`;
-    }
-    dotsContainer.appendChild(element);
-});
+            if (Array.isArray(dayEvents) && dayEvents.length > 0) {
+                // Sort events to ensure consistency. All-day events first, then by time.
+                dayEvents.sort((a, b) => {
+                    if (a.allDay && !b.allDay) return -1;
+                    if (!a.allDay && b.allDay) return 1;
+                    return (a.timeFrom || '').localeCompare(b.timeFrom || '');
+                });
+
+                // Determine the number of dots to show
+                const dotsToShow = dayEvents.slice(0, 3);
+
+                // Render the dots
+                dotsToShow.forEach(event => {
+                    let element;
+                    if (event.type === 'birthday') {
+                        element = document.createElement('i');
+                        element.className = 'bi bi-cake2';
+                    } else {
+                        element = document.createElement('div');
+                        element.className = `event-dot option-dot ${event.type}`;
+                    }
+                    dotsContainer.appendChild(element);
+                });
+
+                // If there are more than 3 events, show the overflow indicator
+                if (dayEvents.length > 3) {
+                    const overflowEl = document.createElement('div');
+                    overflowEl.className = 'event-overflow';
+                    overflowEl.textContent = `+${dayEvents.length - 3}`;
+                    dotsContainer.appendChild(overflowEl);
+                }
             }
             
             dayCell.appendChild(dotsContainer);

--- a/style.css
+++ b/style.css
@@ -1104,6 +1104,7 @@ tr:hover .btn-remove-row {
     gap: 4px;
     /* MODIFIED: This pushes the dots to the bottom of the cell */
     margin-top: auto;
+    align-items: center; /* Add this */
 }
 
 /* Add this new rule below .event-dots-container */
@@ -1677,4 +1678,14 @@ input[type="time"]::-webkit-calendar-picker-indicator {
 -------------------------------------------------- */
 input[type="time"] {
     text-align: center;
+}
+
+.event-overflow {
+    font-size: 0.75rem; /* 12px */
+    font-weight: 600;
+    color: var(--gails-text-secondary);
+    background-color: var(--gails-grey-light);
+    padding: 2px 6px;
+    border-radius: 4px;
+    line-height: 1; /* Ensures consistent height */
 }


### PR DESCRIPTION
- Modified the calendar rendering logic to display a maximum of 3 event dots per day.
- If more than 3 events are present, a '+N' indicator is shown with the count of the remaining events.
- Added CSS to style the new overflow indicator.
- This prevents the calendar day cells from stretching when a large number of events are added to a single day.