### PR TITLE
Fix: Hide calendar button on session timeout

### DIFF
--- a/script.js
+++ b/script.js
@@ -398,6 +398,7 @@ function runApp(app) {
         localStorage.removeItem('lastPlanId');
         localStorage.removeItem('lastViewId');
         localStorage.removeItem('lastActivity');
+        document.getElementById('calendar-fab').classList.add('hidden');
         if (isTimeout) {
             openModal('timeout');
         }


### PR DESCRIPTION
The floating calendar button remained visible on the login screen after a session timeout. This was because the `handleLogout` function, which is triggered on timeout, did not include logic to hide the button.

This change adds a line to the `handleLogout` function in `script.js` to add the 'hidden' class to the calendar button element (`calendar-fab`). This ensures the button is correctly hidden when the user is logged out due to session timeout, aligning its visibility with the user's session state.