### PR TITLE
Fix: Prevent date title from disappearing on 'Add Event' click

### DIFF
--- a/script.js
+++ b/script.js
@@ -2054,7 +2054,6 @@ if (addEventBtn) addEventBtn.addEventListener('click', () => {
     const form = document.getElementById('add-event-form');
     if (form) form.classList.remove('hidden');
     addEventBtn.classList.add('hidden');
-    document.getElementById('day-detail-title').classList.add('hidden');
     // Reset standard fields
     document.getElementById('event-title-input').value = '';
     document.getElementById('event-all-day-toggle').checked = false;


### PR DESCRIPTION
When clicking the "Add Event" button in the calendar modal, the date title was incorrectly being hidden along with the button. This also caused the close button to shift its position.

This commit removes the line of code responsible for hiding the date title, ensuring that only the "Add Event" button is hidden, and the rest of the modal header remains unchanged, as per the intended behavior.