### PR TITLE
Fix: Resolve SyntaxError for firebase import in modal.js

### DIFF
--- a/js/modules/firebase.js
+++ b/js/modules/firebase.js
@@ -1,3 +1,7 @@
+import firebase from "https://www.gstatic.com/firebasejs/9.6.7/firebase-app-compat.js";
+import "https://www.gstatic.com/firebasejs/9.6.7/firebase-auth-compat.js";
+import "https://www.gstatic.com/firebasejs/9.6.7/firebase-firestore-compat.js";
+
 let app;
 let auth;
 let db;
@@ -28,4 +32,4 @@ export async function initializeFirebase() {
 }
 
 // Export the initialized services for use in other modules
-export { app, auth, db };
+export { app, auth, db, firebase };


### PR DESCRIPTION
The module `js/modules/modal.js` was attempting to import the `firebase` object from `js/modules/firebase.js`, but the latter was not exporting it. This resulted in a `SyntaxError`.

This change modifies `js/modules/firebase.js` to import the necessary Firebase compatibility libraries and then export the `firebase` object alongside the existing `app`, `auth`, and `db` exports. This makes the `firebase` object available for import by other modules, resolving the error.