### PR TITLE
Fix: Reset AI chat modal view on open

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -235,35 +235,16 @@ async function showHistoryView() {
     }
 }
 
-export async function openChat() {
+export function openChat() {
     if (DOMElements.modal) {
         DOMElements.modal.classList.remove('hidden');
         DOMElements.chatInput.focus();
 
-        const lastConversationId = sessionStorage.getItem('gails_lastConversationId');
-
-        if (lastConversationId) {
-            await loadChatHistory(lastConversationId);
-        } else {
-            // Fallback to the most recent conversation in Firestore if no session is stored
-            const conversationsRef = db.collection('users').doc(appState.currentUser.uid)
-                                   .collection('plans').doc(appState.currentPlanId)
-                                   .collection('conversations')
-                                   .orderBy('createdAt', 'desc')
-                                   .limit(1);
-            try {
-                const snapshot = await conversationsRef.get();
-                if (snapshot.empty) {
-                    startNewConversation();
-                } else {
-                    const recentId = snapshot.docs[0].id;
-                    await loadChatHistory(recentId);
-                }
-            } catch (error) {
-                console.error("Error loading last conversation:", error);
-                startNewConversation();
-            }
-        }
+        // Always start a new conversation view when opening the modal
+        currentConversationId = null;
+        chatHistory = [];
+        DOMElements.conversationView.innerHTML = '';
+        showConversationView(); // This will correctly show the welcome screen
     }
 }
 


### PR DESCRIPTION
The AI chat modal was previously loading the last conversation upon opening. This has been changed to always display the welcome screen with conversation starters, providing a consistent and clean user experience each time the modal is accessed.

The `openChat` function in `js/chat.js` has been updated to clear the current chat state and UI, effectively starting a new session in the view without deleting any data from the backend. Users can still access their past conversations through the history panel.