### PR TITLE
feat: Add chat history deletion with confirmation

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -301,6 +301,21 @@ async function handleModalAction() {
             document.dispatchEvent(new CustomEvent('event-deletion-confirmed'));
             closeModal();
             break;
+        case 'confirmDeleteConversation':
+            DOMElements.modalTitle.textContent = "Confirm Deletion";
+            DOMElements.modalContent.innerHTML = `<p>Are you sure you want to permanently delete this conversation and all of its messages?</p><p class="mt-2 text-sm text-red-700 bg-red-100 p-3 rounded-lg">This action cannot be undone.</p>`;
+            DOMElements.modalActionBtn.textContent = "Yes, Delete Conversation";
+            DOMElements.modalActionBtn.className = 'btn btn-primary bg-red-600 hover:bg-red-700';
+            // The actual deletion logic will be handled by the listener for this event in chat.js
+            DOMElements.modalActionBtn.onclick = () => {
+                document.dispatchEvent(new CustomEvent('conversation-deletion-confirmed', {
+                    // We reuse the `planId` attribute on the modal to store the conversationId
+                    detail: { conversationId: DOMElements.modalBox.dataset.planId }
+                }));
+                closeModal();
+            };
+            DOMElements.modalCancelBtn.textContent = "Cancel";
+            break;
     }
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -302,19 +302,10 @@ async function handleModalAction() {
             closeModal();
             break;
         case 'confirmDeleteConversation':
-            DOMElements.modalTitle.textContent = "Confirm Deletion";
-            DOMElements.modalContent.innerHTML = `<p>Are you sure you want to permanently delete this conversation and all of its messages?</p><p class="mt-2 text-sm text-red-700 bg-red-100 p-3 rounded-lg">This action cannot be undone.</p>`;
-            DOMElements.modalActionBtn.textContent = "Yes, Delete Conversation";
-            DOMElements.modalActionBtn.className = 'btn btn-primary bg-red-600 hover:bg-red-700';
-            // The actual deletion logic will be handled by the listener for this event in chat.js
-            DOMElements.modalActionBtn.onclick = () => {
-                document.dispatchEvent(new CustomEvent('conversation-deletion-confirmed', {
-                    // We reuse the `planId` attribute on the modal to store the conversationId
-                    detail: { conversationId: DOMElements.modalBox.dataset.planId }
-                }));
-                closeModal();
-            };
-            DOMElements.modalCancelBtn.textContent = "Cancel";
+            document.dispatchEvent(new CustomEvent('conversation-deletion-confirmed', {
+                detail: { conversationId: planId }
+            }));
+            closeModal();
             break;
     }
 }
@@ -473,6 +464,13 @@ export function openModal(type, context = {}) {
             DOMElements.modalContent.innerHTML = `<p>Are you sure you want to permanently delete the plan: <strong class="font-bold">${planName}</strong>?</p><p class="mt-2 text-sm text-red-700 bg-red-100 p-3 rounded-lg">This action is final and cannot be undone.</p>`;
             DOMElements.modalActionBtn.textContent = "Confirm Delete";
             DOMElements.modalActionBtn.className = 'btn btn-primary bg-red-600 hover:bg-red-700';
+            break;
+        case 'confirmDeleteConversation':
+            DOMElements.modalTitle.textContent = "Confirm Deletion";
+            DOMElements.modalContent.innerHTML = `<p>Are you sure you want to permanently delete this conversation and all of its messages?</p><p class="mt-2 text-sm text-red-700 bg-red-100 p-3 rounded-lg">This action cannot be undone.</p>`;
+            DOMElements.modalActionBtn.textContent = "Yes, Delete Conversation";
+            DOMElements.modalActionBtn.className = 'btn btn-primary bg-red-600 hover:bg-red-700';
+            DOMElements.modalCancelBtn.textContent = "Cancel";
             break;
         case 'timeout':
             DOMElements.modalTitle.textContent = "Session Ended";

--- a/style.css
+++ b/style.css
@@ -2703,6 +2703,37 @@ input[type="time"] {
     background-color: var(--gails-red-light);
 }
 
+/* 59. Chat History Deletion Styles */
+.history-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem; /* Add gap between text and button */
+}
+
+.history-item .history-item-text {
+    flex-grow: 1;
+    min-width: 0; /* Allows the text to truncate properly */
+}
+
+.history-item .delete-conversation-btn {
+    flex-shrink: 0;
+    /* Make the button subtle by default */
+    opacity: 0.5;
+    transition: opacity 0.2s ease;
+}
+
+.history-item:hover .delete-conversation-btn {
+    /* Reveal the button more on hover */
+    opacity: 1;
+}
+
+.delete-conversation-btn:hover {
+    /* Add a distinct hover state for the button itself */
+    background-color: var(--gails-red-light);
+    color: var(--gails-red);
+}
+
 .history-item-title {
     font-weight: 600;
     color: var(--gails-text-primary);

--- a/style.css
+++ b/style.css
@@ -2703,6 +2703,12 @@ input[type="time"] {
     background-color: var(--gails-red-light);
 }
 
+/* 60. Z-index fix for nested modals */
+/* Ensure the generic modal can appear on top of other modals (like the chat modal) */
+#modal-overlay {
+    z-index: 1030;
+}
+
 /* 59. Chat History Deletion Styles */
 .history-item {
     display: flex;


### PR DESCRIPTION
Adds the ability for users to delete individual chat conversations from the AI chat modal's history view.

- A delete button (trash icon) is added to each conversation in the history list.
- Clicking the delete button opens a confirmation modal to prevent accidental deletion.
- Upon confirmation, the conversation is removed from Firestore and the UI is updated.
- Implemented using a custom event to decouple the UI modal from the chat deletion logic.