### PR TITLE
Feat: Combine chat history and back buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,7 +405,7 @@
         <div id="chat-modal-header" class="modal-header chat-modal-header">
             <div class="flex items-center gap-3">
                 <button id="chat-options-btn" class="btn btn-secondary btn-icon" title="View History">
-                    <i class="bi bi-three-dots-vertical"></i>
+                    <i class="bi bi-clock-history"></i>
                 </button>
                 <button id="chat-new-btn" class="btn btn-secondary btn-icon" title="New Chat">
                     <i class="bi bi-plus-lg"></i>
@@ -447,9 +447,6 @@
 
             <div id="chat-history-panel" class="chat-history-panel hidden">
                 <div class="history-panel-header">
-                    <button id="back-to-chat-btn" class="btn btn-secondary btn-icon" title="Back to Chat">
-                        <i class="bi bi-arrow-left"></i>
-                    </button>
                     <h4 class="font-bold text-lg">Conversation History</h4>
                 </div>
                 <div id="history-list" class="history-list">

--- a/js/chat.js
+++ b/js/chat.js
@@ -22,7 +22,6 @@ const DOMElements = {
     sendBtn: document.getElementById('chat-send-btn'),
     historyPanel: document.getElementById('chat-history-panel'),
     historyList: document.getElementById('history-list'),
-    backToChatBtn: document.getElementById('back-to-chat-btn'),
 };
 
 function scrollToMessage() {
@@ -190,6 +189,11 @@ async function loadChatHistory(conversationId) {
 function showConversationView() {
     DOMElements.historyPanel.classList.add('hidden');
     DOMElements.conversationView.classList.remove('hidden');
+
+    const icon = DOMElements.optionsBtn.querySelector('i');
+    icon.className = 'bi bi-clock-history';
+    DOMElements.optionsBtn.title = 'View History';
+
     if (chatHistory.length === 0) {
         DOMElements.welcomeScreen.classList.remove('hidden');
         DOMElements.conversationView.classList.add('hidden');
@@ -235,6 +239,11 @@ async function showHistoryView() {
     DOMElements.welcomeScreen.classList.add('hidden');
     DOMElements.conversationView.classList.add('hidden');
     DOMElements.historyPanel.classList.remove('hidden');
+
+    const icon = DOMElements.optionsBtn.querySelector('i');
+    icon.className = 'bi bi-arrow-left';
+    DOMElements.optionsBtn.title = 'Back to Chat';
+
     DOMElements.historyList.innerHTML = '<div class="loading-spinner mx-auto mt-8"></div>';
 
     if (!appState.currentUser || !appState.currentPlanId || !db) {
@@ -353,6 +362,12 @@ export function initializeChat(_appState, _db) {
         }
     });
 
-    DOMElements.optionsBtn.addEventListener('click', showHistoryView);
-    DOMElements.backToChatBtn.addEventListener('click', showConversationView);
+    DOMElements.optionsBtn.addEventListener('click', () => {
+        const isHistoryVisible = !DOMElements.historyPanel.classList.contains('hidden');
+        if (isHistoryVisible) {
+            showConversationView();
+        } else {
+            showHistoryView();
+        }
+    });
 }


### PR DESCRIPTION
The chat modal's "History" and "Back" buttons are now a single, context-aware button.

When viewing the chat, the button shows a history icon and opens the conversation history. When viewing the history, it shows a back arrow icon and returns to the chat.

This improves the UI by making it more intuitive and saving space.