### PR TITLE
Fix: Vertically center chat send button

### DIFF
--- a/style.css
+++ b/style.css
@@ -2562,7 +2562,7 @@ input[type="time"] {
 .chat-input-wrapper {
     position: relative;
     display: flex;
-    align-items: flex-end;
+    align-items: center;
 }
 .chat-input {
     width: 100%;
@@ -2585,7 +2585,8 @@ input[type="time"] {
 .chat-send-btn {
     position: absolute;
     right: 6px;
-    bottom: 6px;
+    top: 50%;
+    transform: translateY(-50%);
     border-radius: 50%;
     width: 36px;
     height: 36px;


### PR DESCRIPTION
This commit addresses a UI alignment issue in the AI chat modal.

The send button was previously aligned to the bottom of the text input area. This change modifies the CSS to vertically center the button within the input wrapper.

- Changed `align-items` on `.chat-input-wrapper` to `center`.
- Replaced `bottom` positioning on `.chat-send-btn` with `top: 50%` and `transform: translateY(-50%)` for proper vertical centering.