### PR TITLE
Fix: adjust chat input to be single-line

### DIFF
--- a/style.css
+++ b/style.css
@@ -2566,14 +2566,13 @@ input[type="time"] {
 }
 .chat-input {
     width: 100%;
-    padding: 0.75rem 3.25rem 0.75rem 1rem;
+    padding: 0.5rem 3.25rem 0.5rem 1rem;
     border-radius: 1.5rem;
     border: 1px solid var(--gails-grey-mid);
     background-color: var(--gails-white);
     resize: none;
-    min-height: 70px;
-    max-height: 150px;
-    overflow-y: auto;
+    height: 44px;
+    overflow-y: hidden;
     line-height: 1.5;
 }
 .chat-input:focus {


### PR DESCRIPTION
The AI chat modal's text input was previously a textarea with a minimum height, causing it to appear as a multi-line field with a scrollbar.

This change adjusts the CSS for the `.chat-input` class to:
- Set a fixed height appropriate for a single line of text.
- Set overflow-y to hidden to remove the scrollbar.
- Adjust vertical padding to keep text centered.

This makes the input field a single line high as requested.