### PR TITLE
feat: Close AI chat modal on session end

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -370,4 +370,7 @@ export function initializeChat(_appState, _db) {
             showHistoryView();
         }
     });
+
+    // When a logout is triggered, ensure the chat modal is closed.
+    document.addEventListener('logout-request', closeChatModal);
 }


### PR DESCRIPTION
Adds an event listener to the chat module to listen for the `logout-request` event. When this event is detected, the chat modal is closed.

This ensures that if the user's session ends for any reason (manual logout, session timeout), the chat modal does not persist on the screen.

The `logout-request` event is dispatched from the `auth` module, and the subsequent redirect to the login page is handled by the main application logic. This change simply hooks into the existing session management flow.