### PR TITLE
feat: Increase AI modal textbox height and padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -2566,12 +2566,12 @@ input[type="time"] {
 }
 .chat-input {
     width: 100%;
-    padding: 0.5rem 3.25rem 0.5rem 1rem;
+    padding: 0.8rem 3.25rem 0.8rem 1.2rem;
     border-radius: 1.5rem;
     border: 1px solid var(--gails-grey-mid);
     background-color: var(--gails-white);
     resize: none;
-    height: 44px;
+    height: 52px;
     overflow-y: hidden;
     line-height: 1.5;
 }


### PR DESCRIPTION
This commit increases the height of the AI modal's chat input text area to 52px from 44px.

It also increases the padding to provide more space for the text within the input field. The top and bottom padding have been increased from 0.5rem to 0.8rem, and the left padding has been increased from 1rem to 1.2rem.