### PR TITLE
feat: Pre-load calendar data for AI chat context

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2,7 +2,7 @@
 
 import { initializeAuth, setupActivityListeners, clearActivityListeners, handleSignOut } from './auth.js';
 import { getFirebaseConfig } from './api.js';
-import { initializeCalendar } from './calendar.js';
+import { initializeCalendar, loadCalendarData } from './calendar.js';
 import { initializeDashboard, renderDashboard } from './dashboard.js';
 import { initializeUI, openModal, handleAIActionPlan, handleShare, initializeCharCounters } from './ui.js';
 import { initializePlanView, showPlanView } from './plan-view.js';
@@ -103,6 +103,7 @@ function runApp(app) {
             if (loginView) loginView.classList.add('hidden');
 
             appState.currentUser = user;
+            await loadCalendarData(db, appState); // Pre-load calendar data for chat AI
             const userDocRef = db.collection('users').doc(user.uid);
             const userDoc = await userDocRef.get();
 


### PR DESCRIPTION
This change ensures that the user's calendar data is loaded immediately after login, making it available to the AI chat feature.

Previously, the calendar data was only loaded when the user opened the calendar modal. This meant that if a user started a chat session without first viewing their calendar, the AI would not have access to their schedule, limiting its ability to provide context-aware responses.

The following changes have been made:
- The `loadCalendarData` function in `js/calendar.js` has been exported and refactored to accept `db` and `appState` arguments.
- `js/main.js` now imports `loadCalendarData` and calls it within the `onAuthStateChanged` listener upon successful user authentication.

This ensures that the AI chat always has the necessary calendar context to assist the user effectively.