### PR TITLE
Fix(upload): Improve header parsing for file uploads

### DIFF
--- a/netlify/functions/upload-file.js
+++ b/netlify/functions/upload-file.js
@@ -17,15 +17,14 @@ export const handler = async (event, context) => {
     return { statusCode: 405, body: 'Method Not Allowed' };
   }
 
-  // Make headers case-insensitive for busboy
-  const headers = Object.fromEntries(
-    Object.entries(event.headers).map(([key, value]) => [key.toLowerCase(), value])
-  );
-
-
   return new Promise((resolve, reject) => {
-    // Pass the lowercase headers to busboy
-    const bb = busboy({ headers: headers });
+    // Busboy needs the content-type header from the event.
+    // The event headers are case-insensitive, so we can access it directly.
+    const bb = busboy({
+      headers: {
+        'content-type': event.headers['content-type'] || event.headers['Content-Type']
+      }
+    });
     const fields = {};
     const files = [];
 


### PR DESCRIPTION
The Netlify function for file uploads (`upload-file.js`) was modified to more robustly handle the `Content-Type` header.

Previously, all request headers were being lowercased and passed to the `busboy` parser. This could cause issues if the Netlify/API Gateway environment modified the headers in unexpected ways.

The new implementation specifically extracts the `content-type` header from the request and passes only that to `busboy`. This makes the parsing logic more resilient to header case changes and other mutations, which is a common issue in serverless environments.