### PR TITLE
fix: Add missing busboy dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@google-cloud/storage": "^7.11.0",
     "@google/generative-ai": "^0.11.3",
+    "busboy": "^1.6.0",
     "firebase-admin": "^12.1.0",
     "pdf-lib": "^1.17.1"
   },


### PR DESCRIPTION
The build was failing because the 'busboy' package was not listed in the dependencies in package.json, but it is used in the `netlify/functions/upload-file.js` function.

This change adds 'busboy' to the dependencies, which resolves the build error.