### PR TITLE
fix: Add missing closing brace to exports.handler

### DIFF
--- a/netlify/functions/upload-file.js
+++ b/netlify/functions/upload-file.js
@@ -125,3 +125,4 @@ exports.handler = async function(event, context) {
             body: JSON.stringify({ error: `An unexpected error occurred: ${error.message}` }),
         };
     }
+}


### PR DESCRIPTION
The build was failing with an "Unexpected end of file" error in netlify/functions/upload-file.js. This was caused by a missing closing curly brace for the exports.handler function.

This commit adds the missing brace to fix the syntax error.